### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "flatbuffers"
+description := "A cross platform serialization library architected for maximum memory efficiency."
+gitrepo     := "https://github.com/google/flatbuffers.git"
+homepage    := "http://google.github.io/flatbuffers"
+version     := 1.11.0 sha256:3f4a286642094f45b1b77228656fbd7ea123964f19502f9ecfd29933fd23a50b https://github.com/google/flatbuffers/archive/v1.11.0.tar.gz
+license     := "Apache-2.0"


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

